### PR TITLE
Allow to specify the fortune database via ZSH_MOTD_DATABASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It's ok if you don't have a certain package installed. You just won't get the pr
 - Add `export ZSH_MOTD_CUSTOM=<A static message>` to your .zshrc to set the message to a static message
 - Add `export ZSH_MOTD_WOTD` to your .zshrc to set the message to a random word
 - Add `export ZSH_MOTD_ALWAYS` to your .zshrc so that the full header is shown every time, instead of the default every 3 hours
+- Add `export ZSH_MOTD_DATABASE` to your .zshrc to specify the fortune database from which messages are picked
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It's ok if you don't have a certain package installed. You just won't get the pr
 - Add `export ZSH_MOTD_ALWAYS` to your .zshrc so that the full header is shown every time, instead of the default every 3 hours
 - Add `export ZSH_MOTD_DATABASE` to your .zshrc to specify the fortune database from which messages are picked
 - Add `export ZSH_MOTD_COW` to your .zshrc to specify the animal display, default to stegosaurus. `cowsay -l` to list them.
+- Set `ZSH_MOTD_NO_WORD_OF_THE_DAY` to a non-empty value to disable the display of a random word.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It's ok if you don't have a certain package installed. You just won't get the pr
 - Add `export ZSH_MOTD_WOTD` to your .zshrc to set the message to a random word
 - Add `export ZSH_MOTD_ALWAYS` to your .zshrc so that the full header is shown every time, instead of the default every 3 hours
 - Add `export ZSH_MOTD_DATABASE` to your .zshrc to specify the fortune database from which messages are picked
+- Add `export ZSH_MOTD_COW` to your .zshrc to specify the animal display, default to stegosaurus. `cowsay -l` to list them.
 
 ## Installation
 

--- a/zsh-motd.plugin.zsh
+++ b/zsh-motd.plugin.zsh
@@ -14,7 +14,7 @@ random_word() {
 }
 
 rainbow_dino() {
-    ( hash cowsay 2>/dev/null && cowsay -n -f stegosaurus || cat ) |
+    ( hash cowsay 2>/dev/null && cowsay -n -f ${ZSH_MOTD_COW-stegosaurus} || cat ) |
     ( hash lolcat 2>/dev/null && lolcat || cat )
 }
 

--- a/zsh-motd.plugin.zsh
+++ b/zsh-motd.plugin.zsh
@@ -51,7 +51,7 @@ if [ -d /etc/update-motd.d ] && [ ! -e "$HOME/.hushlogin" ] && [ -z "$MOTD_SHOWN
 elif [ ! -z ${ZSH_MOTD_ALWAYS+x} ] || ! find $stamp -mmin -179 2> /dev/null | grep -q -m 1 '.'; then
     print_header
     touch $stamp
-else
+elif [ -z "${ZSH_MOTD_NO_WORD_OF_THE_DAY}" ]; then
     echo
     random_word | ( hash lolcat 2>/dev/null && lolcat || cat )
 fi

--- a/zsh-motd.plugin.zsh
+++ b/zsh-motd.plugin.zsh
@@ -19,7 +19,7 @@ rainbow_dino() {
 }
 
 fortune_text() {
-    ( hash fortune 2>/dev/null && fortune || printf "Hey $USER\n" )
+    ( hash fortune 2>/dev/null && fortune "$ZSH_MOTD_DATABASE" || printf "Hey $USER\n" )
 }
 
 print_header() {


### PR DESCRIPTION
/usr/share/fortune contains various databases, and by default fortune picks any of them.
This PR allows the user to select one database in particular, by setting
its name as an environment variable.

I added two more knobs to make the script a bit more configurable: choosing an animal, and disabling the display of a "word of the day".